### PR TITLE
Pin to node version 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "8"
 
 cache: yarn
 before_install:


### PR DESCRIPTION
Yarn warns on v9 and it might introduce problems with certain packages for now.