### PR TITLE
add new lines between import groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
         es6: true,
     },
     rules: {
-        'import/order': 2,
+        'import/order': ['error', { 'newlines-between': 'always' }],
         'react/jsx-filename-extension': 'off',
         'prettier/prettier': [
             'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sharkcore/eslint-config",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-alpha.3",
   "description": "Sharkcore eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tweak the config to place newlines between import groups. So a file might look like this:

```
import fs from 'fs';
import path from 'path';

import index from './';

import sibling from './foo';
```